### PR TITLE
Bugfix/issue31 empty atomic head

### DIFF
--- a/PPSTM_simple.py
+++ b/PPSTM_simple.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/PPSTM_simple.py
+++ b/PPSTM_simple.py
@@ -156,7 +156,9 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
+    # NOTE: This is a temporary fix for the atomic_info_or_head, it will be fixed in the future
+    #       by reading the atomic info from the geometry file
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3))) 
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/4N-coronene/PPSTM_simple.py
+++ b/tests/4N-coronene/PPSTM_simple.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/4N-coronene/PPSTM_simple_pxy.py
+++ b/tests/4N-coronene/PPSTM_simple_pxy.py
@@ -188,7 +188,7 @@ else:
                            y[1], y[2], z[0], z[1], z[2])
     lvec = np.array([[x[0], y[0], z[0]], [x[1]-x[0], 0., 0.],
                     [0., y[1]-y[0], 0.], [0., 0., z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     # print "DEBUG: extent", extent
     # print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/4N-coronene/PPSTM_simple_s.py
+++ b/tests/4N-coronene/PPSTM_simple_s.py
@@ -188,7 +188,7 @@ else:
                            y[1], y[2], z[0], z[1], z[2])
     lvec = np.array([[x[0], y[0], z[0]], [x[1]-x[0], 0., 0.],
                     [0., y[1]-y[0], 0.], [0., 0., z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     # print "DEBUG: extent", extent
     # print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/CuPc/PPSTM_simple.py
+++ b/tests/CuPc/PPSTM_simple.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/CuPc/PPSTM_simple_aims_fixed_npy.py
+++ b/tests/CuPc/PPSTM_simple_aims_fixed_npy.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/FePc_Au/PPSTM_simple.py
+++ b/tests/FePc_Au/PPSTM_simple.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/PTCDA_mol/PPSTM_homo.py
+++ b/tests/PTCDA_mol/PPSTM_homo.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/PTCDA_mol/PPSTM_lumo.py
+++ b/tests/PTCDA_mol/PPSTM_lumo.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/Si_7x7/PPSTM_simple.py
+++ b/tests/Si_7x7/PPSTM_simple.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/TOAT/PPSTM_simple.py
+++ b/tests/TOAT/PPSTM_simple.py
@@ -156,7 +156,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r

--- a/tests/orbitals/PPSTM_simple.py
+++ b/tests/orbitals/PPSTM_simple.py
@@ -160,7 +160,7 @@ else:
     extent = (x[0],x[1],y[0],y[1])
     tip_r  = RS.mkSpaceGrid(x[0],x[1],x[2],y[0],y[1],y[2],z[0],z[1],z[2])
     lvec   = np.array([[x[0],y[0],z[0]],[x[1]-x[0],0.,0.],[0.,y[1]-y[0],0.],[0.,0.,z[1]-z[0]]])
-    atomic_info_or_head = (None, None)
+    atomic_info_or_head = (np.zeros((4,1)), np.zeros((4,3)))
     #print "DEBUG: extent", extent
     #print "DEBUG: lvec", lvec
     tip_r0 = tip_r


### PR DESCRIPTION
fixes #31 

Filler for empty `atomic_head_or_info` fixed from `(None, None)`to `(np.zeros((4,1)), np.zeros((4,3)))`. Tests ran ok, also checked that npy outputs of `tests/CuPc/PPSTM_simple_aims_fixed_npy.py` can be read with [ppafm.io.load_scal_field](https://github.com/Probe-Particle/ppafm/blob/7c0aebb7a1a10357a2817af4f24bf93c1c096e82/ppafm/io.py#L914-L939)