### PR TITLE
Distinguish PNG/XSF filenames for geometry vs non-geometry outputs

### DIFF
--- a/pyPPSTM/visualization.py
+++ b/pyPPSTM/visualization.py
@@ -76,7 +76,10 @@ def plot_png(config, current, didv, voltages, names, lvec, extent, geom_plot,
                 plt.xlabel(r' Tip_x $\AA$')
                 plt.ylabel(r' Tip_y $\AA$')
                 plt.title("dIdV:"+name_plot)
-                save_name = f'didv_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function-voltages[vv]*wf_decay}_eta_{eta:.7f}_{k:03d}.png'
+                save_name = f'didv_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function-voltages[vv]*wf_decay}' \
+                            f'_eta_{eta:.7f}_{k:03d}' \
+                            f'{"_geom" if geom_plot is not None else ""}' \
+                            '.png'
                 plt.savefig(save_dir.joinpath(save_name), bbox_inches='tight')
                 plt.close()
             if current is not None:
@@ -87,7 +90,10 @@ def plot_png(config, current, didv, voltages, names, lvec, extent, geom_plot,
                 plt.xlabel(r' Tip_x $\AA$')
                 plt.ylabel(r' Tip_y $\AA$')
                 plt.title("STM:"+name_plot)
-                save_name = f'STM_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function:.1f}_WF_decay_{wf_decay:.1f}_eta_{eta:.7f}_{k:03d}.png'
+                save_name = f'STM_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function:.1f}_WF_decay_{wf_decay:.1f}' \
+                            f'_eta_{eta:.7f}_{k:03d}' \
+                            f'{"_geom" if geom_plot is not None else ""}' \
+                            '.png'
                 plt.savefig(save_dir.joinpath(save_name), bbox_inches='tight')
                 plt.close()
 
@@ -157,10 +163,16 @@ def save_xsf(config, current, didv, voltages, names, geom_plot, lvec,
     nV, nH = get_number_of_voltages_and_heights(config, current, didv)
     for vv in range(nV):
         if didv is not None:
-            name_file = f'didv_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function-voltages[vv]*wf_decay}_eta_{eta:.7f}.xsf'
+            name_file = f'didv_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function-voltages[vv]*wf_decay}' \
+                        f'_eta_{eta:.7f}' \
+                        f'{"_geom" if geom_plot is not None else ""}' \
+                        '.xsf'
             io.saveXSF(save_dir.joinpath(name_file), didv[vv], lvec, head=xsf_head )
         if current is not None:
-            name_file = f'STM_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function:.1f}_WF_decay_{wf_decay:.1f}_eta_{eta:.7f}.xsf'
+            name_file = f'STM_{names[vv]}_tip_{tip_type}-{tip_orb}_WF_{work_function:.1f}_WF_decay_{wf_decay:.1f}' \
+                        f'_eta_{eta:.7f}' \
+                        f'{"_geom" if geom_plot is not None else ""}' \
+                        '.xsf'
             io.saveXSF(save_dir.joinpath(name_file), current[vv], lvec, head=xsf_head )
 
 def save_npz(config, current, didv, voltages, names, lvec, atomic_info_or_head,

--- a/tests/io/test_save.py
+++ b/tests/io/test_save.py
@@ -1,6 +1,6 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional
+from typing import Optional, List, Tuple
 
 import numpy as np
 import pytest
@@ -55,10 +55,16 @@ class _TestSave(ABC):
                               ("V-scan",       True,       True,  2),
                               ("Voltage-scan", True,       True,  2)),
                              indirect=["current", "didv"])
-    def test_all_output_files_count(self, tmp_path: Path, scan_type, current, didv, expected_files_count: int):
+    def test_all_output_files_count(self,
+                                    tmp_path: Path,
+                                    scan_type,
+                                    current,
+                                    didv,
+                                    expected_files_count: int,
+                                    geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None):
         """Verify the number of created output files."""
 
-        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path)
+        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path, geom_plot=geom_plot)
 
         assert self._count_created_files(tmp_path) == expected_files_count
 
@@ -74,10 +80,16 @@ class _TestSave(ABC):
                               ("V-scan",       True,       True,  1),
                               ("Voltage-scan", True,       True,  1)),
                              indirect=["current", "didv"])
-    def test_didv_files_count(self, tmp_path: Path, scan_type, current, didv, expected_files_count: int):
+    def test_didv_files_count(self,
+                              tmp_path: Path,
+                              scan_type,
+                              current,
+                              didv,
+                              expected_files_count: int,
+                              geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None):
         """Verify the number of created output files for dIdV simulations."""
 
-        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path)
+        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path, geom_plot=geom_plot)
 
         assert self._count_created_files(tmp_path, "didv_*") == expected_files_count
 
@@ -93,10 +105,16 @@ class _TestSave(ABC):
                               ("V-scan",       True,       True,  1),
                               ("Voltage-scan", True,       True,  1)),
                              indirect=["current", "didv"])
-    def test_stm_files_count(self, tmp_path: Path, scan_type, current, didv, expected_files_count: int):
+    def test_stm_files_count(self,
+                             tmp_path: Path,
+                             scan_type,
+                             current,
+                             didv,
+                             expected_files_count: int,
+                             geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None):
         """Verify the number of created output files for STM simulations."""
 
-        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path)
+        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path, geom_plot=geom_plot)
 
         assert self._count_created_files(tmp_path, "STM_*") == expected_files_count
 
@@ -110,12 +128,18 @@ class _TestSave(ABC):
                               ("V-scan",       True,       True,  _WORK_FUNCTION_DECAY),
                               ("Voltage-scan", True,       True,  _WORK_FUNCTION_DECAY)),
                              indirect=["current", "didv"])
-    def test_didv_scan_filename_matches_convention(self, tmp_path: Path, scan_type: str, current, didv, expected_work_function_decay: float):
+    def test_didv_scan_filename_matches_convention(self,
+                                                   tmp_path: Path,
+                                                   scan_type: str,
+                                                   current,
+                                                   didv,
+                                                   expected_work_function_decay: float,
+                                                   geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None):
         """Verify the output filenames for dIdV simulations follow the required format."""
 
-        expected_file_name = self._build_expected_didv_file_name(expected_work_function_decay)
+        expected_file_name = self._build_expected_didv_file_name(expected_work_function_decay, geom_plot=geom_plot)
 
-        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path)
+        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path, geom_plot=geom_plot)
 
         actual_file_name = self._find_one_created_file_name(tmp_path, pattern="didv_*")
 
@@ -128,27 +152,42 @@ class _TestSave(ABC):
                               ("V-scan",       True,      True,    _WORK_FUNCTION_DECAY),
                               ("Voltage-scan", True,      True,    _WORK_FUNCTION_DECAY)),
                              indirect=["current", "didv"])
-    def test_stm_scan_filename_matches_convention(self, tmp_path: Path, scan_type: str, current, didv, expected_work_function_decay: float):
+    def test_stm_scan_filename_matches_convention(self,
+                                                  tmp_path: Path,
+                                                  scan_type: str,
+                                                  current,
+                                                  didv,
+                                                  expected_work_function_decay: float,
+                                                  geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None):
         """Verify the output filenames for STM simulations follow the required format."""
 
-        expected_file_name = self._build_expected_stm_file_name(expected_work_function_decay)
+        expected_file_name = self._build_expected_stm_file_name(expected_work_function_decay, geom_plot=geom_plot)
 
-        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path)
+        self._save(scan_type, current=current, didv=didv, save_dir=tmp_path, geom_plot=geom_plot)
 
         actual_file_name = self._find_one_created_file_name(tmp_path, pattern="STM_*")
 
         assert actual_file_name == expected_file_name
 
     @abstractmethod
-    def _save(self, scan_type: str, save_dir: Path, current: Optional = None, didv: Optional = None):
+    def _save(self,
+              scan_type: str,
+              save_dir: Path,
+              current: Optional = None,
+              didv: Optional = None,
+              geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None):
         pass
 
     @abstractmethod
-    def _build_expected_didv_file_name(self, work_function_decay: float) -> str:
+    def _build_expected_didv_file_name(self,
+                                       work_function_decay: float,
+                                       geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
         pass
 
     @abstractmethod
-    def _build_expected_stm_file_name(self, expected_work_function_decay: float) -> str:
+    def _build_expected_stm_file_name(self,
+                                      work_function_decay: float,
+                                      geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
         pass
 
     @classmethod
@@ -174,36 +213,78 @@ class _TestSave(ABC):
     def _find_one_created_file_name(directory: Path, pattern: str = '*') -> str:
         return next(iter(directory.glob(pattern))).name
 
+    def pytest_generate_tests(self, metafunc):
+        if "geom_plot" in metafunc.fixturenames:
+            metafunc.parametrize("geom_plot", [
+                None,
+                (['C','H'], [11.501016, 3.798985], [6.729982, 11.15007], [5.0, 5.0], [0.0, 0.0]),
+            ], ids=(
+                "",
+                "geom",
+            ))
 
 class _TestSaveData(_TestSave, ABC):
-    def _build_expected_didv_file_name(self, work_function_decay: float) -> str:
+    def _build_expected_didv_file_name(self,
+                                       work_function_decay: float,
+                                       geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
         return f'didv_{self._NAMES[0]}_tip_{self._TIP_TYPE}-{self._TIP_ORB}' \
                f'_WF_{self._WORK_FUNCTION - self._VOLTAGES[0] * work_function_decay}' \
                f'_eta_{self._ETA:.7f}.{self._FILENAME_EXTENSION}'
 
-    def _build_expected_stm_file_name(self, expected_work_function_decay: float) -> str:
+    def _build_expected_stm_file_name(self,
+                                      work_function_decay: float,
+                                      geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
         return f'STM_{self._NAMES[0]}_tip_{self._TIP_TYPE}-{self._TIP_ORB}' \
-               f'_WF_{self._WORK_FUNCTION:.1f}_WF_decay_{expected_work_function_decay:.1f}' \
+               f'_WF_{self._WORK_FUNCTION:.1f}_WF_decay_{work_function_decay:.1f}' \
                f'_eta_{self._ETA:.7f}.{self._FILENAME_EXTENSION}'
 
 
 class _TestSavePlot(_TestSave, ABC):
-    def _build_expected_didv_file_name(self, work_function_decay: float) -> str:
+    def _build_expected_didv_file_name(self,
+                                       work_function_decay: float,
+                                       geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
         return f'didv_{self._NAMES[0]}_tip_{self._TIP_TYPE}-{self._TIP_ORB}' \
                f'_WF_{self._WORK_FUNCTION - self._VOLTAGES[0] * work_function_decay}' \
                f'_eta_{self._ETA:.7f}_{0:03d}.{self._FILENAME_EXTENSION}'
 
-    def _build_expected_stm_file_name(self, expected_work_function_decay: float) -> str:
+    def _build_expected_stm_file_name(self,
+                                      work_function_decay: float,
+                                      geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
         return f'STM_{self._NAMES[0]}_tip_{self._TIP_TYPE}-{self._TIP_ORB}' \
-               f'_WF_{self._WORK_FUNCTION:.1f}_WF_decay_{expected_work_function_decay:.1f}' \
+               f'_WF_{self._WORK_FUNCTION:.1f}_WF_decay_{work_function_decay:.1f}' \
                f'_eta_{self._ETA:.7f}_{0:03d}.{self._FILENAME_EXTENSION}'
+
+
+class _TestSaveGeometry(_TestSave, ABC):
+    def _build_expected_didv_file_name(self,
+                                       work_function_decay: float,
+                                       geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
+        return self._build_expected_file_name(super()._build_expected_didv_file_name(work_function_decay),
+                                              geom_plot=geom_plot)
+
+    def _build_expected_stm_file_name(self,
+                                      work_function_decay: float,
+                                      geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None) -> str:
+        return self._build_expected_file_name(super()._build_expected_stm_file_name(work_function_decay),
+                                              geom_plot=geom_plot)
+
+    @classmethod
+    def _build_expected_file_name(cls,
+                                  file_name: str,
+                                  geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None) -> str:
+        return f"{Path(file_name).stem}_geom.{cls._FILENAME_EXTENSION}" if geom_plot is not None else file_name
 
 
 class TestSaveNpz(_TestSaveData):
     _ATOMIC_INFO_OR_HEAD = (np.zeros((4, 1)), np.zeros((4, 3)))
     _FILENAME_EXTENSION = "npz"
 
-    def _save(self, scan_type: str, save_dir: Path, current: Optional = None, didv: Optional = None):
+    def _save(self,
+              scan_type: str,
+              save_dir: Path,
+              current: Optional = None,
+              didv: Optional = None,
+              geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None):
         visualization.save_npz(self._config(scan_type),
                                current=current,
                                didv=didv,
@@ -214,10 +295,15 @@ class TestSaveNpz(_TestSaveData):
                                save_dir=save_dir)
 
 
-class TestSavePlotPng(_TestSavePlot):
+class TestSavePlotPng(_TestSaveGeometry, _TestSavePlot):
     _FILENAME_EXTENSION = "png"
 
-    def _save(self, scan_type: str, save_dir: Path, current: Optional = None, didv: Optional = None):
+    def _save(self,
+              scan_type: str,
+              save_dir: Path,
+              current: Optional = None,
+              didv: Optional = None,
+              geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None):
         visualization.plot_png(self._config(scan_type),
                                current=current,
                                didv=didv,
@@ -225,7 +311,7 @@ class TestSavePlotPng(_TestSavePlot):
                                names=self._NAMES,
                                lvec=self._LVEC,
                                extent=None,
-                               geom_plot=None,
+                               geom_plot=geom_plot,
                                save_dir=save_dir)
 
 
@@ -242,7 +328,12 @@ class TestSavePlotWsxm(_TestSavePlot):
     ].transpose()
     _FILENAME_EXTENSION = "wsxm"
 
-    def _save(self, scan_type: str, save_dir: Path, current: Optional = None, didv: Optional = None):
+    def _save(self,
+              scan_type: str,
+              save_dir: Path,
+              current: Optional = None,
+              didv: Optional = None,
+              geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None):
         visualization.plot_wsxm(self._config(scan_type),
                                 current=current,
                                 didv=didv,
@@ -252,15 +343,20 @@ class TestSavePlotWsxm(_TestSavePlot):
                                 save_dir=save_dir)
 
 
-class TestSaveXsf(_TestSaveData):
+class TestSaveXsf(_TestSaveGeometry, _TestSaveData):
     _FILENAME_EXTENSION = "xsf"
 
-    def _save(self, scan_type: str, save_dir: Path, current: Optional = None, didv: Optional = None):
+    def _save(self,
+              scan_type: str,
+              save_dir: Path,
+              current: Optional = None,
+              didv: Optional = None,
+              geom_plot: Tuple[List[str], List[float], List[float], List[float], List[float]]|None = None):
         visualization.save_xsf(self._config(scan_type),
                                current=current,
                                didv=didv,
                                voltages=self._VOLTAGES,
                                names=self._NAMES,
                                lvec=self._LVEC,
-                               geom_plot=None,
+                               geom_plot=geom_plot,
                                save_dir=save_dir)


### PR DESCRIPTION
Closes #61

## Summary

Fixes file naming collisions in `pyPPSTM/visualization.py` when geometry overlay/header is enabled.

When `geom_plot` was provided:
- `plot_png()` rendered atom overlays but produced the same base filename as non-geometry runs.
- `save_xsf()` embedded geometry in the XSF header but produced the same base filename as non-geometry runs.

This made “with geometry” and “without geometry” artifacts indistinguishable and could overwrite outputs across runs.

## What changed

- Added deterministic geometry-aware filename handling for visualization outputs.
- When `geom_plot is not None`, generated PNG/XSF filenames now include a suffix (`_geom`).
- When `geom_plot is None`, existing naming behavior is preserved.

## Why

- Prevent accidental overwrites between geometry and non-geometry runs.
- Improve traceability and reproducibility of generated artifacts.

## Scope / Compatibility

- Backward compatible for workflows that do not pass `geom_plot`.
- Intentional filename change only for geometry-enabled outputs.

## Testing

- Verified `plot_png()` output names differ between:
  - `geom_plot=None`
  - `geom_plot=<geometry>`
- Verified `save_xsf()` output names differ between:
  - `geom_plot=None`
  - `geom_plot=<geometry>`
- Confirmed no naming changes for non-geometry runs.